### PR TITLE
ENHANCEMENT Subscribe allowed to work stand alone

### DIFF
--- a/code/APES.php
+++ b/code/APES.php
@@ -210,11 +210,11 @@ class APES extends DataExtension {
 			return;
 		}
 
-		// Only update members which are subscribed
-		if(!$this->isSubscribed()) return;
-
-		// Send subscription update to mailchimp
-		$this->subscribeMailChimpUser();
+		// Only update members which are subscribed (and not pending) or new.
+		if($this->isSubscribed() || !$this->getListStatus() || !$this->isPending()){
+			// Send subscription update to mailchimp
+			$this->subscribeMailChimpUser();
+		}
 		
 	}
 


### PR DESCRIPTION
This allows subscribes to work even if the developer doesn't implement a frontend form to trigger the initial subscription.

This will allow Mailchimp sync on any existing registration forms or via the CMS.

Will only run the sync if the Member isSubscribed OR if their status is false (which indicates they are not on the list and should be added).
