### PR TITLE
Add mock mailchimp API for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,4 @@ You can choose which Member object properties are sync'd even if you have decora
 Member object with additional information i.e. address, phone numbers etc
 
 # License
-Copyright (c) 2015, Cam Findlay
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+See [LICENSE](LICENSE.md)

--- a/code/APES.php
+++ b/code/APES.php
@@ -55,7 +55,7 @@ class APES extends DataExtension
         if (defined('SS_MAILCHIMP_LIST_ID')) {
             return SS_MAILCHIMP_LIST_ID;
         }
-        return $this->owner->config()->mailchimp_list_id;
+        return Config::inst()->get(__CLASS__, 'mailchimp_list_id');
     }
 
     /**

--- a/code/MockMailchimp.php
+++ b/code/MockMailchimp.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * MockMailchimp
+ * 
+ * Use to mock the responses from Mailchimp when running unit tests
+ */
+class MockMailchimp {
+    
+    
+    public function __construct(){
+
+        $this->lists = $this;
+
+    }
+
+
+    public function subscribe($id, $email, $merge_vars=null, $email_type='html', $double_optin=true, $update_existing=false, $replace_interests=true, $send_welcome=false){
+            return array('email' => $email, 'euid' => '12345', 'leid' => '67890');
+    }
+
+    public function memberInfo(){}
+    
+}

--- a/tests/APESTest.php
+++ b/tests/APESTest.php
@@ -1,0 +1,38 @@
+<?php
+
+class APESTest extends SapphireTest
+{
+
+
+    public static $fixture_file = 'apes/tests/APESTest.yml';
+
+    public function setUp()
+    {
+
+        Config::inst()->update(
+            'Injector',
+            'Mailchimp',
+            array('class' => 'MockMailchimp')
+        );
+        parent::setUp();
+
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+    }
+
+    public function testSubscribe()
+    {
+
+        $member = Member::get()->filter('Email', 'joe@bloggs.com')->first();
+
+        $member->subscribeMailChimpUser();
+        $member->write();
+
+        $this->assertEquals('67890', $member->MailchimpID);
+
+    }
+}

--- a/tests/APESTest.yml
+++ b/tests/APESTest.yml
@@ -1,0 +1,5 @@
+Member:
+   subscriber:
+       FirstName: Joe
+       Surname: Bloggs
+       Email: joe@bloggs.com


### PR DESCRIPTION
Attempting to mock mailchimp subscribes for testing

Current issues:
- getting Injector to replace the Mailchimp class with the MockMailchimp class

You can do this in the config.yml 

eg.

``` yaml
Injector:
  Mailchimp:
    class: MockMailchimp
```

however I must be missing something regarding being able to Inject classes during test runs.
